### PR TITLE
Condense HTML whitespace _after_ unquoting attributes

### DIFF
--- a/css_html_js_minify/html_minifier.py
+++ b/css_html_js_minify/html_minifier.py
@@ -140,6 +140,6 @@ def html_minify(html, comments=False):
     html = condense_style(html)
     html = condense_script(html)
     html = clean_unneeded_html_tags(html)
-    html = condense_html_whitespace(html)
     html = unquote_html_attributes(html)
+    html = condense_html_whitespace(html)
     return html.strip()


### PR DESCRIPTION
... to avoid double spaces everywhere.