### PR TITLE
Breaking css minification bug fix: condense_hex_colors breaks 8-digit hex strings

### DIFF
--- a/css_html_js_minify/css_minifier.py
+++ b/css_html_js_minify/css_minifier.py
@@ -206,7 +206,8 @@ def condense_hex_colors(css):
     """Shorten colors from #AABBCC to #ABC where possible."""
     regex = re.compile(
         r"""([^\"'=\s])(\s*)#([0-9a-f])([0-9a-f])([0-9a-f])"""
-        r"""([0-9a-f])([0-9a-f])([0-9a-f])""", re.I | re.S)
+        r"""([0-9a-f])([0-9a-f])([0-9a-f])(?![0-9a-f])""", re.I | re.S)
+    # The above matches a hex string that is 6 digits long, never 8
     match = regex.search(css)
     while match:
         first = match.group(3) + match.group(5) + match.group(7)

--- a/tests/test_css_minifier.py
+++ b/tests/test_css_minifier.py
@@ -1,0 +1,21 @@
+import unittest
+from css_html_js_minify import css_minifier
+
+class Test_CSS_Minifier(unittest.TestCase):
+    def test_css_hex_condense_do_condense(self):
+        css_in = "color: #aabbcc;"
+        css_out = "color: #abc;"
+        self.assertEqual(css_minifier.condense_hex_colors(css_in), css_out)
+
+    def test_hex_condense_no_condense_six(self):
+        css_in = "color: #abcabc;"
+        css_out = "color: #abcabc;"
+        self.assertEqual(css_minifier.condense_hex_colors(css_in), css_out)
+    
+    def test_hex_condense_no_condense_eight(self):
+        css_in = "color: #aabbccdd;"
+        css_out = "color: #aabbccdd;"
+        self.assertEqual(css_minifier.condense_hex_colors(css_in), css_out)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_html_minifier.py
+++ b/tests/test_html_minifier.py
@@ -1,12 +1,12 @@
 import unittest
 from css_html_js_minify.html_minifier import remove_html_comments
 
-class Test_Html_Minifier(unittest.TestCase):
+class Test_HTML_Minifier(unittest.TestCase):
     def test_remove_html_comments(self):
-        html_in = '<p>This is a test</p><!-- Begone -->'
-        html_out = '<p>This is a test</p>'
+        html_in = "<p>This is a test</p><!-- Begone -->"
+        html_out = "<p>This is a test</p>"
 
         self.assertEqual(remove_html_comments(html_in), html_out)
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Changed the regular expression in `condense_hex_colors` to match only 6 digit hex strings using negative look-ahead. Previous behavior would break 8 digit long hex strings, because it would result in an invalid 5 digit hex string. Also added a test file for CSS minification, which contains some tests for hex color minification. 

Closed the original request and reopened this one since I had made some modifications to the master branch which I didn't intend to include in the pull request, now the changes are in their own branch.